### PR TITLE
Tabloid Feature: Add parent scope variable reassignment!

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Tabloid supports binary infix operators for arithmetic and logic.
 
 `IS ACTUALLY` is a way to test equality, like `==` in most other languages. We can also make comparisons with `X BEATS Y` (`x > y`) and `X SMALLER THAN Y` (`x < y`).
 
+We can initialize and assign variables in the current scope with `EXPERTS CLAIM...TO BE`, and reassign variables using `EVIDENCE SHOWS...TO BE`.
+
+```
+EXPERTS CLAIM your_mom TO BE 'big'
+EVIDENCE SHOWS your_mom TO BE 'massive'
+```
+
 We can print the result of any expression with `YOU WON'T WANT TO MISS`. You won't want to miss what you're printing, and now you never will!
 
 ```

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -271,7 +271,11 @@ class App extends Component {
                 </li>
                 <li>
                     <code class="inline fixed block">EXPERTS CLAIM...TO BE</code>
-                    declare or assign to a variable
+                    declare or assign to a variable (in the current scope)
+                </li>
+                <li>
+                    <code class="inline fixed block">EVIDENCE SHOWS...TO BE</code>
+                    reassign a variable
                 </li>
                 <li>
                     <code class="inline fixed block">YOU WON'T WANT TO MISS</code>


### PR DESCRIPTION
Use `EVIDENCE SHOWS...TO BE` to reassign a variable (which may be in the current scope or the parent scope; iterates until root). Throws an error if no variable is found.

The behaviour of `EXPERTS CLAIM` has been retained (both assignment and reassignment in the current scope) for reverse compatibility.